### PR TITLE
ISSUE=11647 balancer was getting stuck when hit max_prefix_len

### DIFF
--- a/python/t/SimpleBalancerTest.py
+++ b/python/t/SimpleBalancerTest.py
@@ -405,7 +405,7 @@ class TestBalance(unittest.TestCase):
         self.assertTrue(res == 1)
         res = self.balancer.setPrefixBW(net2,500,500)
         self.assertTrue(res == 1)
-        self.balancer.balanceByNetBytes( )
+        self.balancer.balanceByNetBytes([] )
 
     def test_balance_by_load(self):
         self.balancer = SimpleBalancer( ignoreSensorLoad = 0,


### PR DESCRIPTION
the balancer should no longer get stuck when it hits its max_prefix_len.  Now it will check to see if that is the only prefix on that node, if it is not then it moves other prefixes off (starting with the smallest) once that is the only prefix on the node, we add it to the ignore list and attempt to balance again
